### PR TITLE
Zero chunks should become 1 chunk when calculating merkle root

### DIFF
--- a/src/Cortex.SimpleSerialize/SszTree.cs
+++ b/src/Cortex.SimpleSerialize/SszTree.cs
@@ -187,6 +187,11 @@ namespace Cortex.SimpleSerialize
                 throw new ArgumentOutOfRangeException("chunks.Length", chunks.Length, $"Chunks length exceeded padded length limit {paddedLength} bytes.");
             }
 
+            if ((ulong)chunks.Length == 0)
+            {
+                chunks = new byte[32];
+            }
+
             if (paddedLength <= BytesPerChunk)
             {
                 return chunks;


### PR DESCRIPTION
According to https://github.com/ethereum/consensus-specs/blob/v0.11.1/ssz/simple-serialize.md:
> next_pow_of_two(i): get the next power of 2 of i, if not already a power of 2, with 0 mapping to 1. Examples: **0->1**, 1->1, 2->2, 3->4, 4->4, 6->8, 9->16