### PR TITLE
Bugfix/concurrent access to static hashing algorithm instance

### DIFF
--- a/src/Cortex.SimpleSerialize/SszTree.cs
+++ b/src/Cortex.SimpleSerialize/SszTree.cs
@@ -232,10 +232,12 @@ namespace Cortex.SimpleSerialize
                 {
                     input = data.Slice(dataIndex, BytesPerChunk << 1);
                 }
-                var success = _hashAlgorithm.TryComputeHash(input, hashes.Slice(index, BytesPerChunk), out var bytesWritten);
-                if (!success || bytesWritten != BytesPerChunk)
-                {
-                    throw new InvalidOperationException("Error generating hash value.");
+                lock (_hashAlgorithm) {
+                    var success = _hashAlgorithm.TryComputeHash(input, hashes.Slice(index, BytesPerChunk), out var bytesWritten);
+                    if (!success || bytesWritten != BytesPerChunk)
+                    {
+                        throw new InvalidOperationException("Error generating hash value.");
+                    }
                 }
             }
             return hashes;
@@ -252,10 +254,12 @@ namespace Cortex.SimpleSerialize
             root.CopyTo(mixed);
             serializedLength.CopyTo(mixed.Slice(BytesPerChunk));
             var hash = new Span<byte>(new byte[BytesPerChunk]);
-            var success = _hashAlgorithm.TryComputeHash(mixed, hash, out var bytesWritten);
-            if (!success || bytesWritten != BytesPerChunk)
-            {
-                throw new InvalidOperationException("Error generating hash value.");
+            lock (_hashAlgorithm) {
+                var success = _hashAlgorithm.TryComputeHash(mixed, hash, out var bytesWritten);
+                if (!success || bytesWritten != BytesPerChunk)
+                {
+                    throw new InvalidOperationException("Error generating hash value.");
+                }
             }
             return hash;
         }

--- a/test/Cortex.SimpleSerialize.Tests/SszTreeTest_ConcurrentAccess.cs
+++ b/test/Cortex.SimpleSerialize.Tests/SszTreeTest_ConcurrentAccess.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace Cortex.SimpleSerialize.Tests
+{
+    [TestClass]
+    public class SszTreeTest_ConcurrentAccess
+    {
+        [TestMethod]
+        public async Task ConcurrentAccessFromMultipleThreads()
+        {
+            var bytes = new byte[64];
+            bytes[0] = 1;
+
+            void Test()
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    var instance = new SszTree(new SszBasicVector(bytes));
+                    Convert.ToBase64String(instance.HashTreeRoot()).ShouldBe("FqurNB+383Difk2tz4F2bdDf0K5kRpR3uyz2YUk4sq8=");
+                }
+            }
+
+            var tasks = Enumerable.Range(1, 5).Select(_ => Task.Run(Test)).ToArray();
+            await Task.WhenAll(tasks);
+        }
+     }
+}


### PR DESCRIPTION
Fixes an issue of using a single static instance of SHA256 HashAlgorithm which is not thread safe (more on that can be found here https://stackoverflow.com/questions/73006466/is-hashalgorithm-computehash-thread-safe or here https://wanderingdeveloper.medium.com/c-cautionary-tail-the-dangers-of-sha256-reuse-2b5bb9c6fde9).

Creating multiple SszTree instances from concurrent threads randomly calculated wrong roots.